### PR TITLE
fix: ogma dependency in the frontend

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,8 @@ import {
   EdgeStyle,
   PixelSize,
   EdgeExtremity,
-  EdgeType
+  EdgeType,
+  GeoModeOptions
 } from 'ogma';
 
 import {Captions} from './captions/captions';
@@ -44,6 +45,7 @@ import {
 import {LKOgma, ANIMATION_DURATION} from './ogma';
 
 export {
+  GeoModeOptions,
   EdgeType,
   EdgeExtremity,
   PixelSize,


### PR DESCRIPTION
@aminerhanemi  I think because of the merge from develop, develop-next has a dependency from ogma, when I understand it should not anymore. So I added it to ogma-helper, to then remove the dependency from the frontend. Tell me if it does not make sense!