### PR TITLE
LKE-3462: Change how Ogma ingest graph data

### DIFF
--- a/src/ogma/index.ts
+++ b/src/ogma/index.ts
@@ -178,6 +178,9 @@ export class LKOgma extends Ogma<LkNodeData, LkEdgeData> {
     this.LKTransformation.initEdgeGroupingStyle();
   }
 
+  /**
+   * Adding nodes then adding edges to the graph
+   */
   public async setGraph(
     graph: RawGraph<LkNodeData, LkEdgeData>
   ): Promise<{
@@ -192,6 +195,9 @@ export class LKOgma extends Ogma<LkNodeData, LkEdgeData> {
     };
   }
 
+  /**
+   * Adding edges to the graph after filtering disconnected ones
+   */
   public async addEdges(edges: Array<RawEdge<LkEdgeData>>): Promise<EdgeList> {
     const filteredEdges = edges.filter((edge) => {
       return this.getNode(edge.source) !== undefined && this.getNode(edge.target) !== undefined;


### PR DESCRIPTION
We want to have a generic way to be sure that Ogma silently remove edges with disconnected edges (source or target missing). 2 changes : 

* rewrite the `addGraph` method to first call `addNodes` then call `addEdges`
* rewrite `addEdges` to filter disconnected edges before adding them to Ogma.