### PR TITLE
Bump Ogma to 3.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3065,9 +3065,9 @@
       }
     },
     "ogma": {
-      "version": "3.3.8",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/ogma/-/ogma-3.3.8.tgz",
-      "integrity": "sha512-t1fxUwNk3TqDKtBudRvml98heGrjZSyDB3PfB2ndGZYjbk6Q/GanK43ueKu79z0jnsOUuHai2QDOcTNEPO6Ang==",
+      "version": "3.4.0",
+      "resolved": "https://nexus3.linkurious.net/repository/npm/ogma/-/ogma-3.4.0.tgz",
+      "integrity": "sha512-vOb/nEujHLf0iSpMZrCvnmB1KE3YrJqT44pIMEyJxl3VVvPNWl+rrETNUqAfShbK5U3gGSOOA8pG2YS2OoGODw==",
       "requires": {
         "@mapbox/mapbox-gl-rtl-text": "^0.2.0",
         "@types/leaflet": ">=1.x",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "lodash": "4.17.15",
     "lodash-es": "4.17.15",
-    "ogma": "3.3.8",
+    "ogma": "3.4.0",
     "rxjs": "6.5.3",
     "sha1": "1.1.1"
   },


### PR DESCRIPTION
I think it would be nice to keep the first two number of the versions of `Ogma` and  `Ogma-Helper` the same, so it is easy for everyone to know where we are. 