### PR TITLE
LKE-5525: Add a stopped flag in Ogma to prevent race condition during visualization switch

### DIFF
--- a/src/ogma/index.ts
+++ b/src/ogma/index.ts
@@ -315,7 +315,7 @@ export class LKOgma extends Ogma<LkNodeData, LkEdgeData> {
    * Do a full reset on ogma and streams of ogma
    */
   public shutDown(): void {
-    this.stopped = false;
+    this.stopped = true;
     this.destroy();
     if (this.store) {
       this.store.clear();

--- a/src/ogma/index.ts
+++ b/src/ogma/index.ts
@@ -39,6 +39,7 @@ interface AddItemOptions {
 }
 
 export class LKOgma extends Ogma<LkNodeData, LkEdgeData> {
+  public stopped: boolean = true;
   public LKStyles!: StylesViz;
   public LKCaptions!: CaptionsViz;
   public LKTransformation!: TransformationsViz;
@@ -188,6 +189,7 @@ export class LKOgma extends Ogma<LkNodeData, LkEdgeData> {
    * add nodes and edges to the viz and init the selection.
    */
   public async init(visualization: {nodes: Array<VizNode>; edges: Array<VizEdge>}): Promise<void> {
+    this.stopped = false;
     this.clearGraph();
     let selectedEntityType: EntityType | undefined = undefined;
     let selectedElements: Array<string> = [];
@@ -313,6 +315,7 @@ export class LKOgma extends Ogma<LkNodeData, LkEdgeData> {
    * Do a full reset on ogma and streams of ogma
    */
   public shutDown(): void {
+    this.stopped = false;
     this.destroy();
     if (this.store) {
       this.store.clear();
@@ -323,6 +326,7 @@ export class LKOgma extends Ogma<LkNodeData, LkEdgeData> {
    * Reset the Ogma instance so that it can be used fresh in the next visulization
    */
   public clearOgmaState(): void {
+    this.stopped = true;
     this.reset();
     if (this.store) {
       this.store.clear();

--- a/src/ogma/index.ts
+++ b/src/ogma/index.ts
@@ -39,7 +39,7 @@ interface AddItemOptions {
 }
 
 export class LKOgma extends Ogma<LkNodeData, LkEdgeData> {
-  public stopped: boolean = true;
+  public stopped = true;
   public LKStyles!: StylesViz;
   public LKCaptions!: CaptionsViz;
   public LKTransformation!: TransformationsViz;


### PR DESCRIPTION
When switching from a visualization to another on (moving from a case to a workspace), race conditions could occurs (e.g. ghost events on nodesAdded). To prevent that, I added a flag `stopped` on Ogma to listen to in frontend to ensure that we can actually listen to events or not.