### PR TITLE
LKE-8537 remove npm "prepare" script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "node": "18.17.1"
   },
   "scripts": {
-    "prepare": "tsc -b",
     "build": "tsc -b",
     "compile": "tsc -b",
     "tsc": "tsc -b",


### PR DESCRIPTION
LKE-8537  remove npm "prepare" script: it is unused and breaks the umbrella sequential build process