### PR TITLE
LKE-10347 feat(ImageExport): verify that the sub-nodes area attached to virtual node before applying styles

### DIFF
--- a/src/ogma/features/nodeGrouping.ts
+++ b/src/ogma/features/nodeGrouping.ts
@@ -123,6 +123,8 @@ export class NodeGroupingTransformation {
         }
       },
       nodeSelector: (node) => {
+        // TODO: Tools.isDefined(node.getSubNodes()) is a work around for an ogma issue visible when using image export plugin with Node grouping
+        // remove when updating to Ogma v5.1.x
         return node.isVirtual() && Tools.isDefined(node.getSubNodes());
       },
       // the style will be updated when data object is updated

--- a/src/ogma/features/nodeGrouping.ts
+++ b/src/ogma/features/nodeGrouping.ts
@@ -123,7 +123,7 @@ export class NodeGroupingTransformation {
         }
       },
       nodeSelector: (node) => {
-        return node.isVirtual();
+        return node.isVirtual() && Tools.isDefined(node.getSubNodes());
       },
       // the style will be updated when data object is updated
       nodeDependencies: {self: {data: true}}


### PR DESCRIPTION
It is due to an Ogma bug that is already fixed in the version in development (there is no open issue to link it to it)