### PR TITLE
Disable the lint quality gate on develop-maintenance

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,4 +12,6 @@ nodeJob {
   runBookeeping = true
 
   runNpmPublish = true
+
+  qualityGates = []
 }


### PR DESCRIPTION
# :warning: DO NOT FORWARD-MERGE THIS PULL REQUEST :warning:

Disable the lint quality gate.

Due to the recent channel shift, the quality gate is failing on `develop-maintenance`. We don't want to fix the lint errors on this channel, so let's simply disable the quality gate on `develop-maintenance`.