### PR TITLE
LKE-11815 feat(visualization): filtered nodes below layer

### DIFF
--- a/src/ogma/features/nodeGrouping.ts
+++ b/src/ogma/features/nodeGrouping.ts
@@ -97,6 +97,11 @@ export class NodeGroupingTransformation {
           style: 'bold'
         },
         layer: -1,
+        detectable: (item): boolean => {
+          const subNodes = item.getSubNodes();
+          // if all subnodes are filtered, the virtual node is not detectable
+          return subNodes!.toArray().some((node) => !node.hasClass('filtered'));
+        },
         color: 'rgba(240, 240, 240)',
         innerStroke: {
           color: '#7f7f7f',

--- a/src/ogma/features/nodeGrouping.ts
+++ b/src/ogma/features/nodeGrouping.ts
@@ -97,11 +97,6 @@ export class NodeGroupingTransformation {
           style: 'bold'
         },
         layer: -1,
-        detectable: (item): boolean => {
-          const subNodes = item.getSubNodes();
-          // if all subnodes are filtered, the virtual node is not detectable
-          return subNodes!.toArray().some((node) => !node.hasClass('filtered'));
-        },
         color: 'rgba(240, 240, 240)',
         innerStroke: {
           color: '#7f7f7f',

--- a/src/ogma/features/styles.ts
+++ b/src/ogma/features/styles.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import * as o from '@linkurious/ogma';
+import Ogma, * as o from '@linkurious/ogma';
 import {
   Badge,
   Edge,
@@ -380,10 +380,10 @@ export class StylesViz {
       name: 'filtered',
       nodeAttributes: {
         opacity: FILTER_OPACITY,
-        layer: (node): number | undefined => {
+        layer: (node): number => {
           // if the node is part of a virtual node, it should be on top
           if (node.getMetaNode() !== null) {
-            return undefined;
+            return 1;
           }
           return -1;
         },

--- a/src/ogma/features/styles.ts
+++ b/src/ogma/features/styles.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import Ogma, * as o from '@linkurious/ogma';
+import * as o from '@linkurious/ogma';
 import {
   Badge,
   Edge,

--- a/src/ogma/features/styles.ts
+++ b/src/ogma/features/styles.ts
@@ -380,10 +380,10 @@ export class StylesViz {
       name: 'filtered',
       nodeAttributes: {
         opacity: FILTER_OPACITY,
-        layer: (node): number => {
+        layer: (node): number | undefined => {
           // if the node is part of a virtual node, it should be on top
-          if (node.getMetaNode() !== undefined) {
-            return 1;
+          if (node.getMetaNode() !== null) {
+            return undefined;
           }
           return -1;
         },

--- a/src/ogma/features/styles.ts
+++ b/src/ogma/features/styles.ts
@@ -406,7 +406,7 @@ export class StylesViz {
         shape: 'circle',
         image: null,
         icon: null,
-        radius: '100%'
+        radius: '50%'
       },
       edgeAttributes: {
         opacity: FILTER_OPACITY,


### PR DESCRIPTION
@davidrapin now that I've checked the code, indeed the code was wrong as you mentionned and it caused a regression. Since getMetanode is never undefined, all filtered changed from layer -1 (bottom layer) to layer 1 (on top of 'normal' nodes).
From Ogma, selected nodes are on layer 2 and hovered are on layer 3, hence the weird behavior in the ticket (where hovered nodes reappear on top of filtered nodes).

For the second change, I asked product if they were ok with it, because it's actually filtering ndoe groups which I don't know if we should. They are ok with it!