### PR TITLE
LKE-12438: Restore commonjs require compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "access": "public"
   },
   "private": false,
-  "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
This is a follow-up of https://github.com/Linkurious/ogma-linkurious-parser/pull/425

With this PR, `ogma-linkurious-parser` is now exported as ESM module `./dist/index.mjs`.

The previous export as a commonJS module is still present in `./dist/index.js`. However, as `"type": "module"` has been added to the `package.json`, this commonJS module is treated as ESM module, and fails to be imported using the `require()` syntax.

The solution here is to remove the `"type": "module"` property from the `package.json`. Another solution would have been to rename all the exported `.js`files as `.cjs` so they are explicitly treated as commonJS.

Reference documentation: https://nodejs.org/docs/latest-v13.x/api/esm.html#esm_enabling