### PR TITLE
Fixed the CommonJS build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   },
   "scripts": {
     "build": "npm run compile && npm run build:bundle",
-    "compile": "tsc --emitDeclarationOnly && npm run tsc:rename",
-    "tsc:rename": "find dist -name '*.js' -exec sh -c 'mv \"$1\" \"${1%.js}.cjs\"' _ {} \\;",
+    "compile": "tsc --emitDeclarationOnly",
     "build:bundle": "vite build",
     "test": "mocha -r tsx tests/**/*.spec.ts",
     "test:unit": "nyc --reporter=text-summary --reporter=cobertura --report-dir=reports  mocha -r tsx --reporter mocha-multi-reporters --reporter-options configFile=.test-reporters.json tests/**/*.spec.ts",

--- a/package.json
+++ b/package.json
@@ -11,16 +11,22 @@
   },
   "private": false,
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "engines": {
     "node": "20.18.0"
   },
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    }
+  },
   "scripts": {
-    "build": "tsc -b && npm run build:bundle",
-    "compile": "tsc -b",
-    "tsc": "tsc -b",
+    "build": "npm run compile && npm run build:bundle",
+    "compile": "tsc --emitDeclarationOnly && npm run tsc:rename",
+    "tsc:rename": "find dist -name '*.js' -exec sh -c 'mv \"$1\" \"${1%.js}.cjs\"' _ {} \\;",
     "build:bundle": "vite build",
     "test": "mocha -r tsx tests/**/*.spec.ts",
     "test:unit": "nyc --reporter=text-summary --reporter=cobertura --report-dir=reports  mocha -r tsx --reporter mocha-multi-reporters --reporter-options configFile=.test-reporters.json tests/**/*.spec.ts",

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -4,12 +4,13 @@ export default defineConfig({
   build: {
     minify: true,
     emptyOutDir: false,
+    sourcemap: true,
     // Set the output directory to 'dist'
     outDir: 'dist',
     lib: {
-      entry: 'src/index.ts',
-      formats: ['es'],
-      fileName: (format) => 'index.mjs'
+      entry: './src/index.ts',
+      formats: ['es', 'cjs'],
+      fileName: (format) => `index.${format === 'es' ? 'm' : 'c'}js`
     },
     rollupOptions: {
       external: ['@linkurious/ogma', '@linkurious/rest-client', 'lodash', 'rxjs']


### PR DESCRIPTION
 - Now `CommonJS` build is handled by `vite`
 - `tsc` is only used to emit declaration files
 - using `.cjs` extension so that `Node` knows the module type.