### PR TITLE
Fixed types export for Typescript 4.7+

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
TypeScript is unable to resolve the `index.d.ts` file while respecting the `"exports"` field in package.json. Since TypeScript 4.7, when `"exports"` is defined, it does not automatically pick up `"types"` unless explicitly specified inside `"exports"`.