### PR TITLE
LKE-12861 fix(ogma-store): update items after geo disabled

### DIFF
--- a/src/ogma/features/reactive.ts
+++ b/src/ogma/features/reactive.ts
@@ -90,6 +90,9 @@ export class RxViz {
     this._ogma.events.on('geoDisabled', () => {
       this._store.dispatch(this.storeItems.bind(this));
     });
+    this._ogma.events.on('geoEnabled', () => {
+      this._store.dispatch(this.storeItems.bind(this));
+    });
 
     this._ogma.events.on('nodesSelected', () => {
       this._store.dispatch(this.storeNodeSelection.bind(this));

--- a/src/ogma/features/reactive.ts
+++ b/src/ogma/features/reactive.ts
@@ -87,6 +87,9 @@ export class RxViz {
     this._ogma.events.on('removeEdges', () => {
       this._store.dispatch(this.storeItems.bind(this));
     });
+    this._ogma.events.on('geoDisabled', () => {
+      this._store.dispatch(this.storeItems.bind(this));
+    });
 
     this._ogma.events.on('nodesSelected', () => {
       this._store.dispatch(this.storeNodeSelection.bind(this));


### PR DESCRIPTION
Make sure the ogma store is updated when going in and out of geo mode. See frontend PR for more details
https://github.com/Linkurious/linkurious-frontend/pull/6113