### PR TITLE
LKE-13187 fix(RemoveItems): type properly the selection in the state and remove DummyNodeList

### DIFF
--- a/src/ogma/features/OgmaStore.ts
+++ b/src/ogma/features/OgmaStore.ts
@@ -5,7 +5,7 @@ import {distinctUntilChanged, map} from 'rxjs/operators';
 
 import {Tools} from '../../tools/tools';
 
-import {DummyNodeList, OgmaState} from './reactive';
+import {OgmaState} from './reactive';
 
 export class OgmaStore extends BehaviorSubject<OgmaState> {
   constructor(d: OgmaState) {
@@ -34,7 +34,7 @@ export class OgmaStore extends BehaviorSubject<OgmaState> {
    */
   public clear(): void {
     this.next({
-      selection: new DummyNodeList() as any,
+      selection: undefined,
       items: {node: [], edge: []},
       changes: undefined,
       animation: false

--- a/src/ogma/features/reactive.ts
+++ b/src/ogma/features/reactive.ts
@@ -8,7 +8,7 @@ import {LKOgma} from '../index';
 import {OgmaStore} from './OgmaStore';
 
 export interface OgmaState {
-  selection: NodeList<LkNodeData, LkEdgeData> | EdgeList<LkEdgeData, LkNodeData>;
+  selection: NodeList<LkNodeData, LkEdgeData> | EdgeList<LkEdgeData, LkNodeData> | undefined;
   items: {node: Array<string | number>; edge: Array<string | number>};
   changes: {entityType: 'node' | 'edge'; input: string | string[] | null; value: any} | undefined;
   /**
@@ -20,7 +20,7 @@ export interface OgmaState {
 export class RxViz {
   private _ogma: Ogma;
   private _store: OgmaStore = new OgmaStore({
-    selection: new DummyNodeList() as any,
+    selection: undefined,
     items: {node: [], edge: []},
     changes: undefined,
     animation: false
@@ -173,9 +173,4 @@ export class RxViz {
       selection: this._ogma.getSelectedEdges()
     };
   }
-}
-
-export class DummyNodeList {
-  public size = 0;
-  public isNode = true;
 }

--- a/src/ogma/features/selectors.ts
+++ b/src/ogma/features/selectors.ts
@@ -3,6 +3,8 @@
 import {EntityType, LkEdgeData, LkNodeData} from '@linkurious/rest-client';
 import {Edge, ItemList, Node} from '@linkurious/ogma';
 
+import {Tools} from '../../tools/tools';
+
 import {OgmaState} from './reactive';
 
 export type SelectionState = 'selection' | 'multiSelection' | 'noSelection';
@@ -34,7 +36,7 @@ export const getSelectionState = (state: OgmaState): SelectionState => {
  * Get the entityType of the current selection
  */
 export const getSelectionEntity = (state: OgmaState): EntityType | undefined => {
-  if (state.selection.size === 0) {
+  if (!Tools.isDefined(state.selection) || state.selection.size === 0) {
     return undefined;
   }
   return (state.selection as ItemList<LkNodeData>).isNode ? EntityType.NODE : EntityType.EDGE;
@@ -46,7 +48,9 @@ export const getSelectionEntity = (state: OgmaState): EntityType | undefined => 
 export const getUniqSelection = (
   state: OgmaState
 ): Node<LkNodeData, LkEdgeData> | Edge<LkEdgeData, LkNodeData> | undefined => {
-  return state.selection.size === 1 ? state.selection.get(0) : undefined;
+  return Tools.isDefined(state.selection) && state.selection.size === 1
+    ? state.selection.get(0)
+    : undefined;
 };
 
 /**


### PR DESCRIPTION
**What:**
Setting the selection in ogma state to undefined instead of "DummyNodeList".

**Why**
selection can be undefined leading to some unexpected error in the frontend. Having the type include undefined will force type checking int the frontend 