### PR TITLE
LKE-13257 feat(NodeGrouping): add subSelection style class and add all selected nodes in ogma state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "sha1": "1.1.1"
       },
       "devDependencies": {
-        "@linkurious/ogma": "5.2.4",
+        "@linkurious/ogma": "5.2.5-PR-4062.6",
         "@linkurious/rest-client": "~4.2.0-develop-stable.250",
         "@types/chai": "4.2.17",
         "@types/lodash": "4.14.182",
@@ -42,7 +42,7 @@
         "node": "22.14.0"
       },
       "peerDependencies": {
-        "@linkurious/ogma": "5.2.4"
+        "@linkurious/ogma": "5.2.5-PR-4062.6"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1018,9 +1018,9 @@
       }
     },
     "node_modules/@linkurious/ogma": {
-      "version": "5.2.4",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/@linkurious/ogma/-/ogma-5.2.4.tgz",
-      "integrity": "sha512-DZcBcw4F9C2BkDLcWGVvIW8sRhnTs/MFR6RWfkyUWo81OtjNi2VS3dcdRi0kaZ2Tjmigi1m36juu6s6bImlXwg==",
+      "version": "5.2.5-PR-4062.6",
+      "resolved": "https://nexus3.linkurious.net/repository/npm/@linkurious/ogma/-/ogma-5.2.5-PR-4062.6.tgz",
+      "integrity": "sha512-aR360e/DHs3OXzV2nQNXTOSsLj5Qq1/tAiYhUcb9YlXTI4KNraYWndzCa8VD9c+weCml7VJwvDpRwGuBqbzUdw==",
       "dev": true,
       "optionalDependencies": {
         "@mapbox/mapbox-gl-rtl-text": "^0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@linkurious/ogma": "5.2.5-PR-4062.6",
-        "@linkurious/rest-client": "~4.2.0-develop-stable.250",
+        "@linkurious/rest-client": "~4.2.0-develop-stable.252",
         "@types/chai": "4.2.17",
         "@types/lodash": "4.14.182",
         "@types/mocha": "5.2.7",
@@ -1030,9 +1030,9 @@
       }
     },
     "node_modules/@linkurious/rest-client": {
-      "version": "4.2.0-develop-stable.250",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/@linkurious/rest-client/-/rest-client-4.2.0-develop-stable.250.tgz",
-      "integrity": "sha512-sS9Y9mGWy5PAb7ODQxjwdmI7qGp0NfuTIHFVU6t6A9s0Zg+FDoDQqY4IdOs6pNAJuifEJMHNFdVwNqUVMZX7wg==",
+      "version": "4.2.0",
+      "resolved": "https://nexus3.linkurious.net/repository/npm/@linkurious/rest-client/-/rest-client-4.2.0.tgz",
+      "integrity": "sha512-Suj8LNENX/86FOh992iHbKQ4VCBatOBCh1TDpThUhmZP0k84M/2D3BZKTKEzdhb9T4OK5G5Jp8DmOMuW42Txvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -58,10 +58,10 @@
     "sha1": "1.1.1"
   },
   "peerDependencies": {
-    "@linkurious/ogma": "5.2.4"
+    "@linkurious/ogma": "5.2.5-PR-4062.6"
   },
   "devDependencies": {
-    "@linkurious/ogma": "5.2.4",
+    "@linkurious/ogma": "5.2.5-PR-4062.6",
     "@linkurious/rest-client": "~4.2.0-develop-stable.250",
     "@types/chai": "4.2.17",
     "@types/lodash": "4.14.182",

--- a/src/ogma/features/nodeGrouping.ts
+++ b/src/ogma/features/nodeGrouping.ts
@@ -234,6 +234,8 @@ export class NodeGroupingTransformation {
       },
       nodeDependencies: {self: {attributes: ['styleRefreshIndex']}}
     });
+
+    this._setSubSelectedClass();
   }
 
   public async refreshNodeGroupingStyle(): Promise<void> {
@@ -607,5 +609,21 @@ export class NodeGroupingTransformation {
       return nodeAttributes.attributes.layoutable;
     }
     return true;
+  }
+
+  /**
+   * Set styles for the class "filtered"
+   */
+  private _setSubSelectedClass(): void {
+    this._ogma.styles.createClass({
+      name: 'subSelection',
+      nodeAttributes: {
+        halo: {
+          width: 4,
+          color: '#e67a8f',
+          strokeColor: '#ccc'
+        }
+      }
+    });
   }
 }

--- a/src/ogma/features/reactive.ts
+++ b/src/ogma/features/reactive.ts
@@ -158,10 +158,9 @@ export class RxViz {
    * Store new node selection in state
    */
   private storeNodeSelection(state: OgmaState): OgmaState {
-    const selectedNodes = this._ogma.getNodes('all').filter((node) => node.isSelected());
     return {
       ...state,
-      selection: selectedNodes
+      selection: this._ogma.getSelectedNodes()
     };
   }
 

--- a/src/ogma/features/reactive.ts
+++ b/src/ogma/features/reactive.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import Ogma, {NodeList, EdgeList} from '@linkurious/ogma';
+import Ogma, {EdgeList, NodeList} from '@linkurious/ogma';
 import {LkEdgeData, LkNodeData} from '@linkurious/rest-client';
 
 import {LKOgma} from '../index';
@@ -158,9 +158,10 @@ export class RxViz {
    * Store new node selection in state
    */
   private storeNodeSelection(state: OgmaState): OgmaState {
+    const selectedNodes = this._ogma.getNodes('all').filter((node) => node.isSelected());
     return {
       ...state,
-      selection: this._ogma.getSelectedNodes()
+      selection: selectedNodes
     };
   }
 

--- a/src/ogma/index.ts
+++ b/src/ogma/index.ts
@@ -369,4 +369,13 @@ export class LKOgma extends Ogma<LkNodeData, LkEdgeData> {
     this.setStyles(this._configuration, baseUrl);
     this.setCaptions(this._configuration);
   }
+
+  /**
+   * An override of the Ogma method getSelectedNodes
+   * originally it was returning only the visible selected nodes
+   * but we need to return all selected nodes, including the one that are part of collapsed groups
+   */
+  public getSelectedNodes(): NodeList<LkNodeData, LkEdgeData> {
+    return this.getNodes('all').filter((node) => node.isSelected());
+  }
 }


### PR DESCRIPTION
**Ticket:**
https://linkurious.atlassian.net/browse/LKE-13257

**What**
Highlight and show the sub-nodes group selection. 

**How**
- Add new styling class: Style group differently when it is collapsed and some of its sub-nodes are selected.
- Update ogma state to include all selected nodes instead of only the visible ones. That will include selected sub-nodes if a collapsed group

