### PR TITLE
LKE-13407 fix(Tools): Support floating value for alpha value in rgba color

### DIFF
--- a/src/tools/ogmaTool.ts
+++ b/src/tools/ogmaTool.ts
@@ -57,14 +57,14 @@ export class OgmaTools {
     if (color === null || !Tools.isStringFilled(color)) {
       return true;
     }
-    const hexRegExp = /#[A-Fa-f0-9]{3,6}/;
+    const hexadecimalColor = /#[A-Fa-f0-9]{3,6}/;
     const rgbRegExp =
       /^rgb\(\s*([01]?\d\d?|2[0-4]\d|25[0-5])\s*,\s*([01]?\d\d?|2[0-4]\d|25[0-5])\s*,\s*([01]?\d\d?|2[0-4]\d|25[0-5])\s*\)$/i;
     const rgbaRegExp =
       /^rgba\(\s*([01]?\d\d?|2[0-4]\d|25[0-5])\s*,\s*([01]?\d\d?|2[0-4]\d|25[0-5])\s*,\s*([01]?\d\d?|2[0-4]\d|25[0-5])\s*,\s*(?:0|1|0?\.\d+)\s*\)$/i;
     let rgb: string;
 
-    if (hexRegExp.test(color)) {
+    if (hexadecimalColor.test(color)) {
       if (color.length < 5) {
         color += color.slice(1);
       }
@@ -85,7 +85,7 @@ export class OgmaTools {
       return true;
     }
 
-    const [r, g, b] = /rgba?\((\d{1,3}),(\d{1,3}),(\d{1,3})(,\d{1,3})?\)/
+    const [r, g, b] = /rgba?\((\d{1,3}),(\d{1,3}),(\d{1,3})(,(?:0|1|0?\.\d+))?\)/
       .exec(rgb.replace(/\s/g, ''))!
       .slice(1, 4);
 

--- a/tests/tools/ogmaTools.spec.ts
+++ b/tests/tools/ogmaTools.spec.ts
@@ -1,0 +1,91 @@
+import {expect} from 'chai';
+import 'mocha';
+
+import {OgmaTools} from '../../src';
+
+describe('OgmaTools.isBright', () => {
+  describe('null and empty values', () => {
+    it('should return true for null', () => {
+      expect(OgmaTools.isBright(null)).to.be.true;
+    });
+
+    it('should return true for empty string', () => {
+      expect(OgmaTools.isBright('')).to.be.true;
+    });
+  });
+
+  describe('hexadecimal colors', () => {
+    it('should correctly identify bright hex colors (6 digits)', () => {
+      expect(OgmaTools.isBright('#FFFFFF')).to.be.true; // White
+      expect(OgmaTools.isBright('#FFD700')).to.be.true; // Gold
+    });
+
+    it('should correctly identify dark hex colors (6 digits)', () => {
+      expect(OgmaTools.isBright('#000000')).to.be.false; // Black
+      expect(OgmaTools.isBright('#8B0000')).to.be.false; // Dark red
+    });
+
+    it('should correctly handle 3-digit hex colors', () => {
+      expect(OgmaTools.isBright('#FFF')).to.be.true; // White
+      expect(OgmaTools.isBright('#000')).to.be.false; // Black
+    });
+  });
+
+  describe('RGB colors', () => {
+    it('should correctly identify bright RGB colors', () => {
+      expect(OgmaTools.isBright('rgb(255, 255, 255)')).to.be.true; // White
+      expect(OgmaTools.isBright('rgb(255, 215, 0)')).to.be.true; // Gold
+    });
+
+    it('should correctly identify dark RGB colors', () => {
+      expect(OgmaTools.isBright('rgb(0, 0, 0)')).to.be.false; // Black
+      expect(OgmaTools.isBright('rgb(139, 0, 0)')).to.be.false; // Dark red
+    });
+
+    it('should handle RGB colors with whitespace', () => {
+      expect(OgmaTools.isBright('rgb( 255, 255, 255 )')).to.be.true;
+    });
+  });
+
+  describe('RGBA colors', () => {
+    it('should correctly identify bright RGBA colors', () => {
+      expect(OgmaTools.isBright('rgba(255, 255, 255, 1)')).to.be.true;
+      expect(OgmaTools.isBright('rgba(255, 255, 255, 0.5)')).to.be.true;
+    });
+
+    it('should correctly identify dark RGBA colors', () => {
+      expect(OgmaTools.isBright('rgba(0, 0, 0, 1)')).to.be.false;
+      expect(OgmaTools.isBright('rgba(0, 0, 0, 0.5)')).to.be.false;
+    });
+  });
+
+  describe('HTML color names', () => {
+    it('should correctly identify bright HTML color names', () => {
+      expect(OgmaTools.isBright('white')).to.be.true;
+      expect(OgmaTools.isBright('yellow')).to.be.true;
+    });
+
+    it('should correctly identify dark HTML color names', () => {
+      expect(OgmaTools.isBright('black')).to.be.false;
+      expect(OgmaTools.isBright('navy')).to.be.false;
+    });
+  });
+
+  describe('threshold cases', () => {
+    it('should identify colors just above the brightness threshold as bright', () => {
+      // Threshold is 255 * 0.7 = 178.5 for weighted RGB
+      expect(OgmaTools.isBright('rgb(179, 179, 179)')).to.be.true;
+    });
+
+    it('should identify colors just below the brightness threshold as dark', () => {
+      expect(OgmaTools.isBright('rgb(178, 178, 178)')).to.be.false;
+    });
+  });
+
+  describe('invalid formats', () => {
+    it('should return true for invalid color formats', () => {
+      expect(OgmaTools.isBright('not-a-color')).to.be.true;
+      expect(OgmaTools.isBright('rgb(300, 0, 0)')).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
**WHAT**
- Fix the regex to support decimal values in the alpha component in the rgba value.
- Add unit tests for isBrith method