### PR TITLE
LKE-13639 fix(PinBadge): use Ogma style rule instead of class to set the pin badge

### DIFF
--- a/src/ogma/features/styles.ts
+++ b/src/ogma/features/styles.ts
@@ -523,6 +523,7 @@ export class StylesViz {
 
   /**
    * Used in other repos to refresh the pin badge style rule
+   * LKE-13639: we are using a style rule instead of an Ogma class to get the right size of the nodes when calling _findPinBadgeScale
    */
   public async refreshPinBadgeStyleRule(): Promise<void> {
     if (!Tools.isDefined(this._pinnedIndicatorRule)) {

--- a/src/ogma/features/styles.ts
+++ b/src/ogma/features/styles.ts
@@ -126,6 +126,7 @@ export class StylesViz {
       text?: TextOptions;
     };
   };
+  private _pinnedIndicatorRule?: StyleRule<LkNodeData, LkEdgeData>;
 
   constructor(
     ogma: LKOgma,
@@ -516,12 +517,20 @@ export class StylesViz {
         }
       }
     });
-    this._ogma.styles.createClass({
-      name: 'pinnedIndicator',
-      nodeAttributes: {
-        badges: {
-          topRight: (node): Badge | undefined => {
-            if (node !== undefined && !node.getAttribute('layoutable')) {
+
+    this._ogma.events.on('addNodes', (nodesEvent) => nodesEvent.nodes.addClass('degreeIndicator'));
+  }
+
+  /**
+   * Used in other repos to refresh the pin badge style rule
+   */
+  public async refreshPinBadgeStyleRule(): Promise<void> {
+    if (!Tools.isDefined(this._pinnedIndicatorRule)) {
+      this._pinnedIndicatorRule = this._ogma.styles.addRule({
+        nodeSelector: (node) => !node.getAttribute('layoutable'),
+        nodeAttributes: {
+          badges: {
+            topRight: (node): Badge | undefined => {
               return {
                 color: BADGE_COLOR,
                 minVisibleSize: 20,
@@ -534,26 +543,24 @@ export class StylesViz {
                   font: 'FontAwesome',
                   scale: 0.4,
                   color: CLEAR_FONT_COLOR,
-                  content: node.getAttribute('layoutable') ? null : '\uf08d'
+                  content: '\uf08d'
                 }
               };
             }
           }
+        },
+        nodeDependencies: {
+          self: {attributes: ['layoutable']}
         }
-      },
-      nodeDependencies: {
-        self: {attributes: ['layoutable']}
-      }
-    });
-    this._ogma.events.on('addNodes', (nodesEvent) => nodesEvent.nodes.addClass('degreeIndicator'));
-    this._ogma.events.on('addNodes', (nodesEvent) => nodesEvent.nodes.addClass('pinnedIndicator'));
-  }
-
-  /**
-   * Delete the rule to display badges
-   */
-  public deleteBadgeRule() {
-    this._ogma.getNodes().removeClasses(['degreeIndicator', 'pinnedIndicator'], 0);
+      });
+      await this._pinnedIndicatorRule.update({
+        // @ts-ignore Suggested  by Ogma team to increase the priority of the rule, but it doesn't work as expected
+        // We are using a timeout in the frontend to ensure that this rule will be applied last
+        priority: 1000
+      });
+    } else {
+      await this._pinnedIndicatorRule.refresh();
+    }
   }
 
   /**


### PR DESCRIPTION
https://linkurious.atlassian.net/browse/LKE-13639
**What:**
Fixing the pin badge size

**How**
Before, we were using Ogma classes to set the badge, but due to how Ogma prioritizes the style rules, it prevents us from calculating the proper scale for the badge size.

Ogma team suggested using a style rule and setting the `priority` value (it is not an exposed API). 

The priority option didn't work as expected (we need to check with Leo why that is but he is off)
I had to use a timeout in the frontend to ensure that the new rule is applied last.