### PR TITLE
fix(lint): no-named-as-default import rule.

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -28,7 +28,6 @@ module.exports = {
     '@typescript-eslint/require-await': ['off'], // Allows async without await
     'import/no-unresolved': ['off'], // Disable non working rule
     'import/order': ['error', {'newlines-between': 'always'}], // Orders imports by ['builtin', 'external', 'parent', 'sibling', 'index']
-    "import/no-named-as-default": ["off"], // Ogma use named exports as default.
     '@typescript-eslint/no-misused-promises': ['error'],
 
     // Shared specific

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -28,6 +28,7 @@ module.exports = {
     '@typescript-eslint/require-await': ['off'], // Allows async without await
     'import/no-unresolved': ['off'], // Disable non working rule
     'import/order': ['error', {'newlines-between': 'always'}], // Orders imports by ['builtin', 'external', 'parent', 'sibling', 'index']
+    "import/no-named-as-default": ["off"], // Ogma use named exports as default.
     '@typescript-eslint/no-misused-promises': ['error'],
 
     // Shared specific

--- a/src/ogma/features/reactive.ts
+++ b/src/ogma/features/reactive.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import Ogma, {EdgeList, NodeList} from '@linkurious/ogma';
+import {EdgeList, NodeList, Ogma} from '@linkurious/ogma';
 import {LkEdgeData, LkNodeData} from '@linkurious/rest-client';
 
 import {LKOgma} from '../index';
@@ -10,7 +10,9 @@ import {OgmaStore} from './OgmaStore';
 export interface OgmaState {
   selection: NodeList<LkNodeData, LkEdgeData> | EdgeList<LkEdgeData, LkNodeData> | undefined;
   items: {node: Array<string | number>; edge: Array<string | number>};
-  changes: {entityType: 'node' | 'edge'; input: string | string[] | null; value: any} | undefined;
+  changes:
+    | {entityType: 'node' | 'edge'; input: string | string[] | null; value: unknown}
+    | undefined;
   /**
    * Indicates whether the positions of nodes or edges are currently transitioning.
    */
@@ -25,7 +27,7 @@ export class RxViz {
     changes: undefined,
     animation: false
   });
-  private _animationThrottle: any;
+  private _animationThrottle?: NodeJS.Timeout;
 
   constructor(ogma: LKOgma) {
     this._ogma = ogma;

--- a/src/ogma/features/selectors.ts
+++ b/src/ogma/features/selectors.ts
@@ -2,6 +2,7 @@
 
 import {EntityType, LkEdgeData, LkNodeData} from '@linkurious/rest-client';
 import type {Edge, ItemList, Node} from '@linkurious/ogma';
+import {LkProperty} from '@linkurious/rest-client/dist/src/api/graphItemTypes';
 
 import {Tools} from '../../tools/tools';
 
@@ -85,7 +86,9 @@ export const getUniqSelectionEntity = (state: OgmaState): 'node' | 'edge' | unde
 /**
  * Return the properties of the current selection if there's only one item selected
  */
-export const getSelectionProperties = (state: OgmaState): Array<{key: string; value: any}> => {
+export const getSelectionProperties = (
+  state: OgmaState
+): Array<{key: string; value: LkProperty}> => {
   const uniqSelection = getUniqSelection(state);
   if (uniqSelection !== undefined) {
     const properties = uniqSelection.getData().properties;

--- a/src/ogma/index.ts
+++ b/src/ogma/index.ts
@@ -19,9 +19,10 @@ import type {
   RadialLayoutOptions,
   RawEdge,
   RawGraph,
-  RawNode
+  RawNode,
+  Filter
 } from '@linkurious/ogma';
-import Ogma from '@linkurious/ogma';
+import {Ogma, Edge} from '@linkurious/ogma';
 
 import {StyleRules} from '..';
 import {Tools} from '../tools/tools';
@@ -314,7 +315,13 @@ export class LKOgma extends Ogma<LkNodeData, LkEdgeData> {
   /**
    * Return the list of non filtered edges
    */
-  public getNonFilteredEdges(items?: Array<any>): EdgeList<LkEdgeData, LkNodeData> {
+  public getNonFilteredEdges(
+    items?:
+      | Array<string>
+      | Filter
+      | Edge<LkEdgeData, LkNodeData>[]
+      | EdgeList<LkEdgeData, LkNodeData>
+  ): EdgeList<LkEdgeData, LkNodeData> {
     return Tools.isDefined(items)
       ? this.getEdges(items).filter((i) => !i.hasClass('filtered'))
       : this.getEdges('raw').filter((i) => !i.hasClass('filtered'));
@@ -324,7 +331,7 @@ export class LKOgma extends Ogma<LkNodeData, LkEdgeData> {
    * Return the list of filtered edges
    */
   public getFilteredEdges(
-    items?: Array<any>,
+    items?: Array<string>,
     filter: 'visible' | 'raw' | 'all' = 'raw'
   ): EdgeList<LkEdgeData, LkNodeData> {
     return Tools.isDefined(items)

--- a/tests/filters/filters.spec.ts
+++ b/tests/filters/filters.spec.ts
@@ -3,7 +3,7 @@
 import {expect} from 'chai';
 import 'mocha';
 import type {RawEdge, RawNode} from '@linkurious/ogma';
-import Ogma from '@linkurious/ogma';
+import {Ogma} from '@linkurious/ogma';
 import {LkEdgeData, LkNodeData} from '@linkurious/rest-client';
 
 import {Filters} from '../../src';

--- a/tests/ogma/index.spec.ts
+++ b/tests/ogma/index.spec.ts
@@ -2,7 +2,7 @@
 
 import {expect} from 'chai';
 import 'mocha';
-import Ogma, {NodeList} from '@linkurious/ogma';
+import {Ogma, NodeList} from '@linkurious/ogma';
 import {LkEdgeData, LkNodeData} from '@linkurious/rest-client';
 
 import {Tools} from '../../src/tools/tools';

--- a/tests/styles/edgeAttributes.spec.ts
+++ b/tests/styles/edgeAttributes.spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import 'mocha';
-import Ogma, {Edge} from '@linkurious/ogma';
+import {Ogma, Edge} from '@linkurious/ogma';
 import {LkEdgeData, LkNodeData, OgmaEdgeShape, SelectorType} from '@linkurious/rest-client';
 
 import {EdgeAttributes, StyleRules, StyleRule} from '../../src';

--- a/tests/styles/nodeAttributes.spec.ts
+++ b/tests/styles/nodeAttributes.spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import 'mocha';
-import Ogma, {Node} from '@linkurious/ogma';
+import {Ogma, Node} from '@linkurious/ogma';
 import {LkEdgeData, LkNodeData, SelectorType} from '@linkurious/rest-client';
 
 import {NodeAttributes, StyleRule, StyleRules} from '../../src';


### PR DESCRIPTION
As this rule blocks chekctyle and Ogma use this import rule.