### PR TITLE
LKE-13839 Pin npm version to min 10.9 to fix package lock node update. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "engines": {
-    "node": "22.17.1"
+    "node": "22.17.1",
+    "npm": "^10.9.0"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
In order to avoid package lock beeing out of sync with package when renovate using npm 11.6 version.