### PR TITLE
fix(Eslint): Change name of default import 

### DIFF
--- a/src/ogma/features/reactive.ts
+++ b/src/ogma/features/reactive.ts
@@ -25,7 +25,7 @@ export class RxViz {
     changes: undefined,
     animation: false
   });
-  private _animationThrottle: any;
+  private _animationThrottle?: NodeJS.Timeout;
 
   constructor(ogma: LKOgma) {
     this._ogma = ogma;

--- a/src/ogma/features/reactive.ts
+++ b/src/ogma/features/reactive.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import Ogma, {EdgeList, NodeList} from '@linkurious/ogma';
+import OgmaLib, {EdgeList, NodeList} from '@linkurious/ogma';
 import {LkEdgeData, LkNodeData} from '@linkurious/rest-client';
 
 import {LKOgma} from '../index';
@@ -18,7 +18,7 @@ export interface OgmaState {
 }
 
 export class RxViz {
-  private _ogma: Ogma;
+  private _ogma: OgmaLib;
   private _store: OgmaStore = new OgmaStore({
     selection: undefined,
     items: {node: [], edge: []},

--- a/src/ogma/features/reactive.ts
+++ b/src/ogma/features/reactive.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import {EdgeList, NodeList, Ogma} from '@linkurious/ogma';
+import Ogma, {EdgeList, NodeList} from '@linkurious/ogma';
 import {LkEdgeData, LkNodeData} from '@linkurious/rest-client';
 
 import {LKOgma} from '../index';
@@ -10,9 +10,7 @@ import {OgmaStore} from './OgmaStore';
 export interface OgmaState {
   selection: NodeList<LkNodeData, LkEdgeData> | EdgeList<LkEdgeData, LkNodeData> | undefined;
   items: {node: Array<string | number>; edge: Array<string | number>};
-  changes:
-    | {entityType: 'node' | 'edge'; input: string | string[] | null; value: unknown}
-    | undefined;
+  changes: {entityType: 'node' | 'edge'; input: string | string[] | null; value: any} | undefined;
   /**
    * Indicates whether the positions of nodes or edges are currently transitioning.
    */
@@ -27,7 +25,7 @@ export class RxViz {
     changes: undefined,
     animation: false
   });
-  private _animationThrottle?: NodeJS.Timeout;
+  private _animationThrottle: any;
 
   constructor(ogma: LKOgma) {
     this._ogma = ogma;

--- a/src/ogma/features/reactive.ts
+++ b/src/ogma/features/reactive.ts
@@ -10,7 +10,9 @@ import {OgmaStore} from './OgmaStore';
 export interface OgmaState {
   selection: NodeList<LkNodeData, LkEdgeData> | EdgeList<LkEdgeData, LkNodeData> | undefined;
   items: {node: Array<string | number>; edge: Array<string | number>};
-  changes: {entityType: 'node' | 'edge'; input: string | string[] | null; value: any} | undefined;
+  changes:
+    | {entityType: 'node' | 'edge'; input: string | string[] | null; value: unknown}
+    | undefined;
   /**
    * Indicates whether the positions of nodes or edges are currently transitioning.
    */

--- a/src/ogma/features/selectors.ts
+++ b/src/ogma/features/selectors.ts
@@ -2,7 +2,6 @@
 
 import {EntityType, LkEdgeData, LkNodeData} from '@linkurious/rest-client';
 import type {Edge, ItemList, Node} from '@linkurious/ogma';
-import {LkProperty} from '@linkurious/rest-client/dist/src/api/graphItemTypes';
 
 import {Tools} from '../../tools/tools';
 
@@ -86,9 +85,7 @@ export const getUniqSelectionEntity = (state: OgmaState): 'node' | 'edge' | unde
 /**
  * Return the properties of the current selection if there's only one item selected
  */
-export const getSelectionProperties = (
-  state: OgmaState
-): Array<{key: string; value: LkProperty}> => {
+export const getSelectionProperties = (state: OgmaState): Array<{key: string; value: any}> => {
   const uniqSelection = getUniqSelection(state);
   if (uniqSelection !== undefined) {
     const properties = uniqSelection.getData().properties;

--- a/src/ogma/features/selectors.ts
+++ b/src/ogma/features/selectors.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import {EntityType, LkEdgeData, LkNodeData} from '@linkurious/rest-client';
+import {EntityType, LkEdgeData, LkNodeData, LkProperty} from '@linkurious/rest-client';
 import type {Edge, ItemList, Node} from '@linkurious/ogma';
 
 import {Tools} from '../../tools/tools';
@@ -85,7 +85,9 @@ export const getUniqSelectionEntity = (state: OgmaState): 'node' | 'edge' | unde
 /**
  * Return the properties of the current selection if there's only one item selected
  */
-export const getSelectionProperties = (state: OgmaState): Array<{key: string; value: any}> => {
+export const getSelectionProperties = (
+  state: OgmaState
+): Array<{key: string; value: LkProperty}> => {
   const uniqSelection = getUniqSelection(state);
   if (uniqSelection !== undefined) {
     const properties = uniqSelection.getData().properties;

--- a/src/ogma/index.ts
+++ b/src/ogma/index.ts
@@ -10,7 +10,9 @@ import {
   VizNode
 } from '@linkurious/rest-client';
 import type {
+  Edge,
   EdgeList,
+  Filter,
   ForceLayoutOptions,
   HierarchicalLayoutOptions,
   NodeId,
@@ -314,7 +316,13 @@ export class LKOgma extends OgmaLib<LkNodeData, LkEdgeData> {
   /**
    * Return the list of non filtered edges
    */
-  public getNonFilteredEdges(items?: Array<any>): EdgeList<LkEdgeData, LkNodeData> {
+  public getNonFilteredEdges(
+    items?:
+      | Array<string>
+      | Filter
+      | Edge<LkEdgeData, LkNodeData>[]
+      | EdgeList<LkEdgeData, LkNodeData>
+  ): EdgeList<LkEdgeData, LkNodeData> {
     return Tools.isDefined(items)
       ? this.getEdges(items).filter((i) => !i.hasClass('filtered'))
       : this.getEdges('raw').filter((i) => !i.hasClass('filtered'));
@@ -324,7 +332,11 @@ export class LKOgma extends OgmaLib<LkNodeData, LkEdgeData> {
    * Return the list of filtered edges
    */
   public getFilteredEdges(
-    items?: Array<any>,
+    items?:
+      | Array<string>
+      | Filter
+      | Edge<LkEdgeData, LkNodeData>[]
+      | EdgeList<LkEdgeData, LkNodeData>,
     filter: 'visible' | 'raw' | 'all' = 'raw'
   ): EdgeList<LkEdgeData, LkNodeData> {
     return Tools.isDefined(items)

--- a/src/ogma/index.ts
+++ b/src/ogma/index.ts
@@ -21,7 +21,7 @@ import type {
   RawGraph,
   RawNode
 } from '@linkurious/ogma';
-import Ogma from '@linkurious/ogma';
+import OgmaLib from '@linkurious/ogma';
 
 import {StyleRules} from '..';
 import {Tools} from '../tools/tools';
@@ -41,7 +41,7 @@ interface AddItemOptions {
   virtual?: boolean;
 }
 
-export class LKOgma extends Ogma<LkNodeData, LkEdgeData> {
+export class LKOgma extends OgmaLib<LkNodeData, LkEdgeData> {
   public LKStyles!: StylesViz;
   public LKCaptions!: CaptionsViz;
   public LKTransformation!: TransformationsViz;

--- a/src/ogma/index.ts
+++ b/src/ogma/index.ts
@@ -19,10 +19,9 @@ import type {
   RadialLayoutOptions,
   RawEdge,
   RawGraph,
-  RawNode,
-  Filter
+  RawNode
 } from '@linkurious/ogma';
-import {Ogma, Edge} from '@linkurious/ogma';
+import Ogma from '@linkurious/ogma';
 
 import {StyleRules} from '..';
 import {Tools} from '../tools/tools';
@@ -315,13 +314,7 @@ export class LKOgma extends Ogma<LkNodeData, LkEdgeData> {
   /**
    * Return the list of non filtered edges
    */
-  public getNonFilteredEdges(
-    items?:
-      | Array<string>
-      | Filter
-      | Edge<LkEdgeData, LkNodeData>[]
-      | EdgeList<LkEdgeData, LkNodeData>
-  ): EdgeList<LkEdgeData, LkNodeData> {
+  public getNonFilteredEdges(items?: Array<any>): EdgeList<LkEdgeData, LkNodeData> {
     return Tools.isDefined(items)
       ? this.getEdges(items).filter((i) => !i.hasClass('filtered'))
       : this.getEdges('raw').filter((i) => !i.hasClass('filtered'));
@@ -331,7 +324,7 @@ export class LKOgma extends Ogma<LkNodeData, LkEdgeData> {
    * Return the list of filtered edges
    */
   public getFilteredEdges(
-    items?: Array<string>,
+    items?: Array<any>,
     filter: 'visible' | 'raw' | 'all' = 'raw'
   ): EdgeList<LkEdgeData, LkNodeData> {
     return Tools.isDefined(items)

--- a/tests/filters/filters.spec.ts
+++ b/tests/filters/filters.spec.ts
@@ -3,7 +3,7 @@
 import {expect} from 'chai';
 import 'mocha';
 import type {RawEdge, RawNode} from '@linkurious/ogma';
-import Ogma from '@linkurious/ogma';
+import OgmaLib from '@linkurious/ogma';
 import {LkEdgeData, LkNodeData} from '@linkurious/rest-client';
 
 import {Filters} from '../../src';
@@ -243,7 +243,7 @@ describe('Filters', () => {
     target: 19
   } as RawEdge<LkEdgeData>;
 
-  const ogma = new Ogma<LkNodeData, LkEdgeData>();
+  const ogma = new OgmaLib<LkNodeData, LkEdgeData>();
   ogma.addNodes(ogmaFilteredNodes);
   ogma.addEdge(ogmaFilteredEdge);
 

--- a/tests/filters/filters.spec.ts
+++ b/tests/filters/filters.spec.ts
@@ -3,7 +3,7 @@
 import {expect} from 'chai';
 import 'mocha';
 import type {RawEdge, RawNode} from '@linkurious/ogma';
-import {Ogma} from '@linkurious/ogma';
+import Ogma from '@linkurious/ogma';
 import {LkEdgeData, LkNodeData} from '@linkurious/rest-client';
 
 import {Filters} from '../../src';

--- a/tests/ogma/index.spec.ts
+++ b/tests/ogma/index.spec.ts
@@ -2,7 +2,7 @@
 
 import {expect} from 'chai';
 import 'mocha';
-import {Ogma, NodeList} from '@linkurious/ogma';
+import Ogma, {NodeList} from '@linkurious/ogma';
 import {LkEdgeData, LkNodeData} from '@linkurious/rest-client';
 
 import {Tools} from '../../src/tools/tools';

--- a/tests/ogma/index.spec.ts
+++ b/tests/ogma/index.spec.ts
@@ -2,14 +2,14 @@
 
 import {expect} from 'chai';
 import 'mocha';
-import Ogma, {NodeList} from '@linkurious/ogma';
+import OgmaLib, {NodeList} from '@linkurious/ogma';
 import {LkEdgeData, LkNodeData} from '@linkurious/rest-client';
 
 import {Tools} from '../../src/tools/tools';
 
 describe('Tools.getHiddenNeighbors', () => {
   it('should return the number of hidden neighbors', () => {
-    const ogma = new Ogma();
+    const ogma = new OgmaLib();
     ogma.addGraph({
       nodes: [
         {id: 0},

--- a/tests/styles/edgeAttributes.spec.ts
+++ b/tests/styles/edgeAttributes.spec.ts
@@ -1,15 +1,15 @@
 import {expect} from 'chai';
 import 'mocha';
-import Ogma, {Edge} from '@linkurious/ogma';
+import OgmaLib, {Edge} from '@linkurious/ogma';
 import {LkEdgeData, LkNodeData, OgmaEdgeShape, SelectorType} from '@linkurious/rest-client';
 
 import {EdgeAttributes, StyleRules, StyleRule} from '../../src';
 
 describe('EdgeAttributes', () => {
   let edge: Edge<LkEdgeData, LkNodeData>;
-  let ogma: Ogma;
+  let ogma: OgmaLib;
   beforeEach(() => {
-    ogma = new Ogma();
+    ogma = new OgmaLib();
     ogma.addNodes([
       {id: 0, data: {categories: ['CITY'], properties: {name: 'Paris'}}},
       {

--- a/tests/styles/edgeAttributes.spec.ts
+++ b/tests/styles/edgeAttributes.spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import 'mocha';
-import {Ogma, Edge} from '@linkurious/ogma';
+import Ogma, {Edge} from '@linkurious/ogma';
 import {LkEdgeData, LkNodeData, OgmaEdgeShape, SelectorType} from '@linkurious/rest-client';
 
 import {EdgeAttributes, StyleRules, StyleRule} from '../../src';

--- a/tests/styles/nodeAttributes.spec.ts
+++ b/tests/styles/nodeAttributes.spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import 'mocha';
-import Ogma, {Node} from '@linkurious/ogma';
+import OgmaLib, {Node} from '@linkurious/ogma';
 import {LkEdgeData, LkNodeData, SelectorType} from '@linkurious/rest-client';
 
 import {NodeAttributes, StyleRule, StyleRules} from '../../src';
@@ -17,9 +17,9 @@ const widgetNode_2_category = {
 let node_1_category: Node<LkNodeData, LkEdgeData>, node_2_category: Node<LkNodeData, LkEdgeData>;
 
 describe('NodeAttributes', function () {
-  let ogma: Ogma;
+  let ogma: OgmaLib;
   beforeEach(() => {
-    ogma = new Ogma();
+    ogma = new OgmaLib();
     ogma.addNodes([
       {id: 2, data: {categories: ['CITY'], properties: {name: 'Paris'}}},
       {id: 1, data: {categories: ['CITY', 'TRANSACTION'], properties: {name: 'Lyon'}}}

--- a/tests/styles/nodeAttributes.spec.ts
+++ b/tests/styles/nodeAttributes.spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import 'mocha';
-import {Ogma, Node} from '@linkurious/ogma';
+import Ogma, {Node} from '@linkurious/ogma';
 import {LkEdgeData, LkNodeData, SelectorType} from '@linkurious/rest-client';
 
 import {NodeAttributes, StyleRule, StyleRules} from '../../src';


### PR DESCRIPTION
Replace Ogma with OgmaLib when importing as default, fixing `Using exported name 'Ogma' as identifier for default export`