### PR TITLE
LKE-14058 fix(NodeGrouping): fix wrong collapsed state when removing and adding a group again

### DIFF
--- a/src/ogma/features/nodeGrouping.ts
+++ b/src/ogma/features/nodeGrouping.ts
@@ -427,11 +427,9 @@ export class NodeGroupingTransformation {
       .getAdjacentEdges({filter: 'raw'})
       .filter((edge) => edge.getData('type') === rule.groupingOptions.edgeType)
       .get(0);
-    const centralNode =
-      rule.groupingOptions.centralNodeIs === 'source'
-        ? firstAdjacentEdge.getSource()
-        : firstAdjacentEdge.getTarget();
-    return centralNode;
+    return rule.groupingOptions.centralNodeIs === 'source'
+      ? firstAdjacentEdge.getSource()
+      : firstAdjacentEdge.getTarget();
   }
 
   private _getPropertyValueGroupId(
@@ -439,7 +437,9 @@ export class NodeGroupingTransformation {
     rule: NodeGroupingByPropertyValue
   ) {
     const propertyValue = this._findGroupingPropertyValue(node);
-    return `${rule.groupingOptions.itemTypes.join('-')}-${propertyValue}`.toLowerCase().trim();
+    return `${rule.groupingOptions.itemTypes.join('-')}-${propertyValue}-${Math.random()}`
+      .toLowerCase()
+      .trim();
   }
 
   private _getAdjacentEdgeGroupId(


### PR DESCRIPTION
Generate a random id for node groups to avoid unexpected behaviour due to Ogma cache