### PR TITLE
LKE-14058 chore(): Revert node collapse state fix 

### DIFF
--- a/src/ogma/features/nodeGrouping.ts
+++ b/src/ogma/features/nodeGrouping.ts
@@ -437,9 +437,7 @@ export class NodeGroupingTransformation {
     rule: NodeGroupingByPropertyValue
   ) {
     const propertyValue = this._findGroupingPropertyValue(node);
-    return `${rule.groupingOptions.itemTypes.join('-')}-${propertyValue}-${Math.random()}`
-      .toLowerCase()
-      .trim();
+    return `${rule.groupingOptions.itemTypes.join('-')}-${propertyValue}`.toLowerCase().trim();
   }
 
   private _getAdjacentEdgeGroupId(


### PR DESCRIPTION
Reverting https://github.com/Linkurious/ogma-linkurious-parser/pull/503

As the generated group id is used to define which groups are in the same group, having it generated randomly creates where each node is in a separate group