### PR TITLE
LKE-14214 fix(Node Grouping): First grouping apply: Fix layout

### DIFF
--- a/src/ogma/features/nodeGrouping.ts
+++ b/src/ogma/features/nodeGrouping.ts
@@ -48,7 +48,7 @@ export class NodeGroupingTransformation {
    */
   public async initTransformation(): Promise<void> {
     // We use this flag to avoid running the layout in onGroupUpdate the first time the transformation is created
-    let init = true;
+    let init = false;
 
     if (this.transformation === undefined) {
       this.transformation = this._ogma.transformations.addNodeGrouping({

--- a/src/ogma/features/nodeGrouping.ts
+++ b/src/ogma/features/nodeGrouping.ts
@@ -47,9 +47,6 @@ export class NodeGroupingTransformation {
    * Group the nodes based on a category type and a property value
    */
   public async initTransformation(): Promise<void> {
-    // We use this flag to avoid running the layout in onGroupUpdate the first time the transformation is created
-    let init = false;
-
     if (this.transformation === undefined) {
       this.transformation = this._ogma.transformations.addNodeGrouping({
         // node with same value will be part of the same group
@@ -81,7 +78,7 @@ export class NodeGroupingTransformation {
           };
         },
         onGroupUpdate: (n, subNodes) => {
-          if (subNodes.size === 1 || init) {
+          if (subNodes.size === 1) {
             return;
           }
           return {
@@ -106,7 +103,6 @@ export class NodeGroupingTransformation {
       await this.refreshTransformation();
     }
     await this._ogma.transformations.afterNextUpdate();
-    init = false;
   }
 
   /**


### PR DESCRIPTION
LKE-14214

Removing a boolean that prevented node grouping layout from running during the first application of a node group. Bug most likely coming from a change in the frontend where the inner layout configuration would run twice, and now doesn't run at all.