### PR TITLE
LKE-14640 fix: ogma gpu fallback (bump ogma to 5.3.12)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "sha1": "1.1.1"
       },
       "devDependencies": {
-        "@linkurious/ogma": "5.3.11",
+        "@linkurious/ogma": "5.3.12",
         "@linkurious/rest-client": "~4.3.3-develop.42",
         "@types/chai": "4.2.17",
         "@types/lodash": "4.14.182",
@@ -43,7 +43,7 @@
         "npm": "^11.6.1"
       },
       "peerDependencies": {
-        "@linkurious/ogma": "5.3.11"
+        "@linkurious/ogma": "5.3.12"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1042,9 +1042,9 @@
       }
     },
     "node_modules/@linkurious/ogma": {
-      "version": "5.3.11",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/@linkurious/ogma/-/ogma-5.3.11.tgz",
-      "integrity": "sha512-QYRUn7AlDSG0R869ZQSKp52TwByoXgKDB8vJzB6934BqPYiHvex0iS3PA5vWrk0cxFc4eM/7pswvwn/RKmAl5g==",
+      "version": "5.3.12",
+      "resolved": "https://nexus3.linkurious.net/repository/npm/@linkurious/ogma/-/ogma-5.3.12.tgz",
+      "integrity": "sha512-CTRg8l4rls25twhFWU3HRmxBji6IfmG1In/X6b3dY/Ac3UVqLiwxLnY8mJ4z10Tlh0+QEhSCM0CE+4NlcOxXgw==",
       "dev": true,
       "optionalDependencies": {
         "@mapbox/mapbox-gl-rtl-text": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -60,10 +60,10 @@
     "sha1": "1.1.1"
   },
   "peerDependencies": {
-    "@linkurious/ogma": "5.3.11"
+    "@linkurious/ogma": "5.3.12"
   },
   "devDependencies": {
-    "@linkurious/ogma": "5.3.11",
+    "@linkurious/ogma": "5.3.12",
     "@linkurious/rest-client": "~4.3.3-develop.42",
     "@types/chai": "4.2.17",
     "@types/lodash": "4.14.182",


### PR DESCRIPTION
Ogma GPU fallback to CPU was broken (cf https://linkurious.atlassian.net/browse/LKE-14640)

https://github.com/Linkurious/ogma/releases/tag/5.3.12